### PR TITLE
fix: roman

### DIFF
--- a/designs/roman.js
+++ b/designs/roman.js
@@ -44,11 +44,19 @@ function draw(ctx, seed) {
   seed = bytesToNibbles(seed);
   let size = 1;
   let numbers = split(seed, 3);
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
   ctx.strokeStyle = "";
   ctx.fillStyle = "black";
   ctx.textAlign = "center";
   ctx.textBaseline = "bottom";
   ctx.font = size / 3 + "px serif";
+
+  const textMetrics =  ctx.measureText(roman(numbers[0]));
+  const totalHeight = textMetrics.actualBoundingBoxAscent + textMetrics.actualBoundingBoxDescent;
+  const translate = size - totalHeight * 3;
+  ctx.translate(0, translate / 2);
+
   for (let i = 0; i < 3; ++i) {
     ctx.fillText(roman(numbers[i]), size / 2, (size / 3) * (i + 1), size);
   }


### PR DESCRIPTION
Translate a bit before drawing numerals to prevent clip a the top.

After:
![Screenshot 2024-08-28 at 17 41 08](https://github.com/user-attachments/assets/8ccf3a79-0d7e-4fca-9ecf-b495bb10fa44)

Before:
![Screenshot 2024-08-28 at 17 40 32](https://github.com/user-attachments/assets/8da72c36-bba9-411f-aeea-ad41c7206c26)
